### PR TITLE
Revert "snap: drop x86_64 libdrm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Path|Description|Use
 bin/graphics-core22-provider-wrapper|Sets up all the environment|Run your application through it
 ||
 drirc.d|App-specific workarounds|Layout to /usr/share/drirc.d
+libdrm|Needed by mesa on AMD GPUs|Layout to /usr/share/libdrm
 X11|X11 locales etc|Layout to /usr/share/X11
 ||
 mir-quirks|Mir configuration for driver support|Mir specific

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,6 +59,18 @@ parts:
       - usr/lib
       - usr/share/glvnd
 
+  drm:
+    # DRM userspace
+    #   o libdrm.so.2
+    after: [i386-repo]  # because LP#2009278
+    plugin: nil
+    stage-packages:
+      - libdrm2
+      - libdrm-common
+    prime:
+      - usr/lib
+      - usr/share/libdrm
+
   va:
     # Video Acceleration API
     #   o libva.so.2
@@ -161,6 +173,7 @@ parts:
       if [ `arch` = "x86_64" ]; then craftctl default; fi
     prime:
       - usr/lib
+      - usr/share/libdrm
 
   va-i386:
     # Video Acceleration API
@@ -243,6 +256,7 @@ parts:
   file-list:
     after:
     - apis
+    - drm
     - dri
     - va
     - x11
@@ -290,6 +304,7 @@ slots:
         # Required at the top-level by graphics-core22
         - $SNAP/bin
         - $SNAP/usr/share/drirc.d
+        - $SNAP/usr/share/libdrm
         - $SNAP/usr/share/X11
 
         # Internal, pointed at by the above wrapper


### PR DESCRIPTION
This reverts commit 769a4e0ec406652b9d545c2671e8bde6acce6687.

Still don't have access to the `core22` snap version: https://github.com/snapcore/snapd/pull/12694; also realized it's potentially needed for newer AMD GPUs.