### PR TITLE
scripts: handle GBM_BACKENDS_PATH for Mesa

### DIFF
--- a/scripts/bin/graphics-core22-provider-wrapper.in
+++ b/scripts/bin/graphics-core22-provider-wrapper.in
@@ -6,6 +6,7 @@ ARCH_TRIPLETS=( @ARCH_TRIPLETS@ )
 
 # VDPAU_DRIVER_PATH only supports a single path, rely on LD_LIBRARY_PATH instead
 for arch in ${ARCH_TRIPLETS[@]}; do
+  GBM_BACKENDS_PATH=${GBM_BACKENDS_PATH:+$GBM_BACKENDS_PATH:}${SELF}/lib/${arch}/gbm
   LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${SELF}/lib/${arch}:${SELF}/lib/${arch}/vdpau
   LIBGL_DRIVERS_PATH=${LIBGL_DRIVERS_PATH:+$LIBGL_DRIVERS_PATH:}${SELF}/lib/${arch}/dri/
   LIBVA_DRIVERS_PATH=${LIBVA_DRIVERS_PATH:+$LIBVA_DRIVERS_PATH:}${SELF}/lib/${arch}/dri/
@@ -43,6 +44,15 @@ if [ -d "/var/lib/snapd/lib/gl32/vdpau" ]; then
   LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/var/lib/snapd/lib/gl32/vdpau
 fi
 
+if [ -d "/var/lib/snapd/lib/gl/gbm" ]; then
+  GBM_BACKENDS_PATH=${GBM_BACKENDS_PATH}:/var/lib/snapd/lib/gl/gbm
+fi
+
+if [ -d "/var/lib/snapd/lib/gl32/gbm" ]; then
+  GBM_BACKENDS_PATH=${GBM_BACKENDS_PATH}:/var/lib/snapd/lib/gl32/gbm
+fi
+
+export GBM_BACKENDS_PATH
 export LD_LIBRARY_PATH
 export LIBGL_DRIVERS_PATH
 export LIBVA_DRIVERS_PATH


### PR DESCRIPTION
Newer Mesa defers to GBM backends.

---

This is a backport of canonical/mesa-2404#28.